### PR TITLE
Remove specific java version references

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,12 +54,12 @@ android {
     compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        // sourceCompatibility JavaVersion.VERSION_11
+        // targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.majorVersion
+        // jvmTarget = JavaVersion.VERSION_11.majorVersion
     }
 
     defaultConfig {
@@ -71,7 +71,7 @@ android {
     lintOptions {
         abortOnError false
     }
-   
+
     publishing {
         singleVariant("release") {
             withSourcesJar()


### PR DESCRIPTION
Hello! I tried using this library, but ran into an issue with my Java version. Currently in the package, there is a hardcoded version 11, and I'm using version 17. Taking these lines out makes it so the version is inherited from the project, which makes the compilation work on my machine.

The package functions perfectly on iOS and Android from what I can tell. Nice work!